### PR TITLE
do not publish new package on pull request

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,8 +3,7 @@ name: Publish Package
 on:
   push:
     branches: [ main ]
-  pull_request:
-    branches: [ main]
+
 
 jobs:
   build:


### PR DESCRIPTION
we should not publish a new flutter package when some one sends a pull request.Only publish it when its merged on main.