### PR TITLE
Fix: Add namespace to ant_media_flutter plugin

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -26,6 +26,7 @@ apply plugin: 'kotlin-android'
 
 android {
     compileSdkVersion 31
+    namespace "com.example.ant_media_flutter"
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
This pull request addresses a build issue with the `ant_media_flutter` plugin caused by a missing namespace declaration.

**Problem:**

Android Gradle Plugin (AGP) versions 7.0 and higher require a namespace to be explicitly defined in the `build.gradle` file for Android modules. The `ant_media_flutter` plugin was missing this namespace, resulting in the following error:

```
A problem occurred configuring project ':ant_media_flutter'.

Could not create an instance of type com.android.build.api.variant.impl.LibraryVariantBuilderImpl.

> Namespace not specified. Specify a namespace in the module's build file. See https://d.android.com/r/tools/upgrade-assistant/set-namespace for information about setting the namespace.

If you've specified the package attribute in the source AndroidManifest.xml, you can use the AGP Upgrade Assistant to migrate to the namespace value in the build file. Refer to https://d.android.com/r/tools/upgrade-assistant/agp-upgrade-assistant for general information about using the AGP Upgrade Assistant.

```

Please review and merge this pull request to fix the issue.




